### PR TITLE
Decrease binary filesize and skip invalid episodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,12 @@ version = "0.1.0"
 authors = ["niniib <ninib0@protonmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 reqwest = "0.9.24"
-image = "0.23.3"
+image = { version = "0.23.3", default-features = false, features = ["png"] }
 colored = "1.9.3"
-regex = "1.3.5"
-serde_json = "1.0.48"
-anyhow = "1.0.27"
+regex = "1.3.6"
+serde_json = "1.0.51"
+anyhow = "1.0.28"
 clap = "2.33.0"
-rand = "0.7.3"
 urlencoding = "1.0.0"

--- a/src/downloader/gounlimited.rs
+++ b/src/downloader/gounlimited.rs
@@ -17,6 +17,6 @@ pub fn new(url: &str) -> Result<Downloader, Error> {
     Ok(Downloader {
         url: String::from(url),
         video_url,
-        file_name: format!("v.mp4"),
+        file_name: String::from("v.mp4"),
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,9 +163,9 @@ fn run() -> Result<(), Error> {
             let link = link.as_str();
             let hoster = Host::get_from_name(link);
             let downloader = match hoster {
-                Host::Vivo => Some(downloader::vivo::new(link)?),
-                Host::Vidoza => Some(downloader::vidoza::new(link)?),
-                Host::GoUnlimited => Some(downloader::gounlimited::new(link)?),
+                Host::Vivo => Some(downloader::vivo::new(link)),
+                Host::Vidoza => Some(downloader::vidoza::new(link)),
+                Host::GoUnlimited => Some(downloader::gounlimited::new(link)),
                 _ => None,
             };
             if downloader.is_none() {
@@ -173,6 +173,16 @@ fn run() -> Result<(), Error> {
                 exit(1);
             }
             let downloader = downloader.unwrap();
+            if downloader.is_err() {
+                println!(
+                    "{}",
+                    format!("Failed to download from {}. Skipping...", link)
+                        .as_str()
+                        .red()
+                );
+                continue;
+            }
+            let downloader = downloader?;
             let episode_name = format!("{}/{}.{}", output, pattern, downloader.get_extension());
             println!(
                 "{}",


### PR DESCRIPTION
The app won't crash anymore after it encounters an invalid URL, instead it will skip the episode.

I also tried to decrease the file size.
instead of `10,5 MB (stripped)` its only `5,7 MB (stripped)`